### PR TITLE
filter Foundry test contracts in the baseline runner

### DIFF
--- a/baseline-runner/baseline_runner.py
+++ b/baseline-runner/baseline_runner.py
@@ -28,6 +28,29 @@ from openai import OpenAI
 console = Console()
 
 
+def is_test_file(path: Path) -> bool:
+    """Return True for test contracts that should not be analyzed as audit targets.
+
+    The plain ``'test' in name`` check misses Foundry test contracts such as
+    ``Counter.t.sol`` (there is no ``test`` substring in the name) and contracts
+    placed under a ``test/`` directory. Both are handled explicitly so they don't
+    inflate the file count or findings. This only ever excludes more files; it
+    never re-includes any that the previous check already dropped.
+
+    Pass a repo-relative path (e.g. ``path.relative_to(source_dir)``): the
+    directory check looks at every path component, so an absolute path whose
+    parent directories happen to contain ``test`` (say a data root named
+    ``audit-tests/``) must not be handed in directly, or it would filter every
+    file in the repo.
+    """
+    name = path.name.lower()
+    if name.endswith(".t.sol"):
+        return True
+    if any(part.lower() in {"test", "tests"} for part in path.parts):
+        return True
+    return "test" in name
+
+
 class Severity(str, Enum):
     """Vulnerability severity levels."""
     CRITICAL = "critical"
@@ -258,9 +281,17 @@ Identify and report security vulnerabilities found."""
             for pattern in patterns:
                 files.extend(source_dir.glob(pattern))
         
-        # Remove duplicates and filter
+        # Remove duplicates and filter (test files are matched on the repo-relative
+        # path so directories above source_dir cannot trigger the test-dir check)
         files = list(set(files))
-        files = [f for f in files if f.is_file() and 'test' not in f.name.lower()]
+
+        def _repo_relative(p: Path) -> Path:
+            try:
+                return p.relative_to(source_dir)
+            except ValueError:
+                return Path(p.name)
+
+        files = [f for f in files if f.is_file() and not is_test_file(_repo_relative(f))]
         
         if not files:
             console.print(f"[yellow]No files found to analyze[/yellow]")

--- a/tests/test_baseline_filter.py
+++ b/tests/test_baseline_filter.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Tests for test-contract filtering in the baseline runner (issue #12)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add the baseline-runner directory to the path
+sys.path.insert(0, str(Path(__file__).parent.parent / "baseline-runner"))
+
+from baseline_runner import is_test_file
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        # Real audit targets are kept
+        ("src/Vault.sol", False),
+        ("src/Token.sol", False),
+        ("contracts/Governance.sol", False),
+        # Foundry test contracts: no "test" substring in the name (issue #12)
+        ("test/Counter.t.sol", True),
+        ("src/Counter.t.sol", True),
+        # Contracts under a test directory
+        ("test/Helper.sol", True),
+        ("tests/Fixtures.sol", True),
+        # Existing name-substring behaviour still holds
+        ("src/MyTest.sol", True),
+        ("src/TestUtils.sol", True),
+        # Nested repo-relative paths behave the same at any depth
+        ("packages/core/test/Fixtures.sol", True),
+        ("packages/core/src/Vault.sol", False),
+        # Foundry deploy scripts are out of scope (only test contracts are filtered)
+        ("script/Deploy.s.sol", False),
+    ],
+)
+def test_is_test_file(path, expected):
+    assert is_test_file(Path(path)) is expected


### PR DESCRIPTION
Fixes #12.

The baseline runner drops files with `test` in the name, but that misses Foundry test contracts like `Counter.t.sol` (no `test` substring) and contracts under a `test/` directory, so they get analyzed as sources and inflate the file count / findings.

I pulled the filter into a small `is_test_file()` helper that also catches `*.t.sol` and `test/`/`tests/` directories. It matches on the repo-relative path (so a data root whose own path contains `test` cannot filter every file), and it only ever excludes more files - nothing the old check already dropped gets re-included, so baselines can't silently grow.

```bash
$ python -m pytest tests/test_baseline_filter.py -q
12 passed
```